### PR TITLE
reset session states on startup

### DIFF
--- a/src/main/java/uk/gov/hmcts/cft/idam/testingsupportapi/repo/TestingSessionRepo.java
+++ b/src/main/java/uk/gov/hmcts/cft/idam/testingsupportapi/repo/TestingSessionRepo.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.cft.idam.testingsupportapi.repo;
 
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import uk.gov.hmcts.cft.idam.testingsupportapi.repo.model.TestingSession;
 import uk.gov.hmcts.cft.idam.testingsupportapi.repo.model.TestingState;
@@ -15,5 +17,9 @@ public interface TestingSessionRepo extends CrudRepository<TestingSession, Strin
 
     List<TestingSession> findTop10ByCreateDateBeforeAndStateOrderByCreateDateAsc(ZonedDateTime timestamp,
                                                                                  TestingState state);
+
+    @Query("UPDATE TestingSession ts set ts.state=?1 where ts.state != ?1")
+    @Modifying
+    int updateAllSessionStates(TestingState state);
 
 }

--- a/src/main/java/uk/gov/hmcts/cft/idam/testingsupportapi/startup/StartupEventListener.java
+++ b/src/main/java/uk/gov/hmcts/cft/idam/testingsupportapi/startup/StartupEventListener.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.cft.idam.testingsupportapi.startup;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.cft.idam.testingsupportapi.repo.TestingSessionRepo;
+import uk.gov.hmcts.cft.idam.testingsupportapi.repo.model.TestingState;
+
+import javax.transaction.Transactional;
+
+@Slf4j
+@Component
+public class StartupEventListener {
+
+    private final TestingSessionRepo testingSessionRepo;
+
+    public StartupEventListener(TestingSessionRepo testingSessionRepo) {
+        this.testingSessionRepo = testingSessionRepo;
+    }
+
+    @Transactional
+    @EventListener
+    public void resetSessionStateOnStartup(ContextRefreshedEvent event) {
+        int changed = testingSessionRepo.updateAllSessionStates(TestingState.ACTIVE);
+        log.info("Reset session state on startup for {} session(s)", changed);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/cft/idam/testingsupportapi/startup/StartupEventListenerTest.java
+++ b/src/test/java/uk/gov/hmcts/cft/idam/testingsupportapi/startup/StartupEventListenerTest.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.cft.idam.testingsupportapi.startup;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.cft.idam.testingsupportapi.repo.TestingSessionRepo;
+import uk.gov.hmcts.cft.idam.testingsupportapi.repo.model.TestingState;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class StartupEventListenerTest {
+
+
+    @Mock
+    TestingSessionRepo testingSessionRepo;
+
+    @InjectMocks
+    StartupEventListener underTest;
+
+    @Test
+    public void testResetSessionStateOnStartup() {
+        underTest.resetSessionStateOnStartup(null);
+        verify(testingSessionRepo, times(1)).updateAllSessionStates(TestingState.ACTIVE);
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

The queue for idam-testing-support-api is in-memory, so when the app is restarted all of the queued tasks (to delete users etc.) are lost. Sessions are only deleted once their dependencies have been removed, so on startup we can reset all of the existing sessions to be ACTIVE which will cause them to go through the expiry process from scratch, repopulating the queue with expired dependency tasks.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
