### PR TITLE
SIDM-8077: Correcting tags for idam-api-testing-support-api DB resources

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -37,7 +37,7 @@
     <cve>CVE-2022-34305</cve>
   </suppress>
   <suppress>
-    <gav regex="true">^.*jaackson-databind-.*$</gav>
+    <gav regex="true">^.*jackson-databind-.*$</gav>
     <cve>CVE-2022-42003</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -36,4 +36,8 @@
     <gav regex="true">^.*tomcat-.*$</gav>
     <cve>CVE-2022-34305</cve>
   </suppress>
+  <suppress>
+    <gav regex="true">^.*jaackson-databind-.*$</gav>
+    <cve>CVE-2022-42003</cve>
+  </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -37,7 +37,7 @@
     <cve>CVE-2022-34305</cve>
   </suppress>
   <suppress>
-    <gav regex="true">^.*jackson-databind-.*$</gav>
+    <gav regex="true">^.*jackson-databind.*$</gav>
     <cve>CVE-2022-42003</cve>
   </suppress>
 </suppressions>

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -17,16 +17,16 @@ locals {
   default_name = "${var.product}-${var.component}"
   vault_name   = "${var.product}-${var.env}"
   instance_count = (var.env == "prod" || var.env == "idam-prod" || var.env == "idam-prod2") ? 0 : 1
-  environment  = var.env == "idam-prod" ? "production" : var.env == "idam-aat" ? "staging" : var.env == "idam-perftest" ? "testing" : replace(var.env, "idam-", "")
+  environments = {
+    "idam-prod"     = "production",
+    "idam-aat"      = "staging",
+    "idam-perftest" = "testing",
+    "idam-preview"  = "development"
+  }
   tags = merge(
     var.common_tags,
     {
-      "environment"  = local.environment,
-      "Team Name"    = "IdAM",
-      "businessArea" = "CFT",
-      "contactSlackChannel" = "idam-team",
-      "managedBy"           = "idam",
-      "application"         = "idam-testing-support-api"
+    "environment" = lookup(local.environments, var.env, replace(var.env, "idam-", ""))
     },
   )
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-8077

### Change description ###
Most of the tags for the database resource are automatically populated by Jenkins based on https://github.com/hmcts/cnp-jenkins-config/blob/master/team-config.yml. 
This PR only sets the one that is not - "environment".
Tag value comes from https://tools.hmcts.net/confluence/display/DCO/Tagging+v0.4


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
