### PR TITLE
Register JodaModule in ObjectMapper

### DIFF
--- a/src/main/java/uk/gov/hmcts/cft/idam/testingsupportapi/config/NotifyConfig.java
+++ b/src/main/java/uk/gov/hmcts/cft/idam/testingsupportapi/config/NotifyConfig.java
@@ -11,7 +11,9 @@ import uk.gov.hmcts.cft.idam.notify.IdamNotificationClient;
 public class NotifyConfig {
 
     @Bean
-    public IdamNotificationClient notificationClient(@Value("${notify.key}") String notificationKey, ObjectMapper objectMapper) {
+    public IdamNotificationClient notificationClient(
+        @Value("${notify.key}") String notificationKey,
+        ObjectMapper objectMapper) {
         objectMapper.registerModule(new JodaModule());
         return new IdamNotificationClient(notificationKey);
     }

--- a/src/main/java/uk/gov/hmcts/cft/idam/testingsupportapi/config/NotifyConfig.java
+++ b/src/main/java/uk/gov/hmcts/cft/idam/testingsupportapi/config/NotifyConfig.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.cft.idam.testingsupportapi.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,7 +11,8 @@ import uk.gov.hmcts.cft.idam.notify.IdamNotificationClient;
 public class NotifyConfig {
 
     @Bean
-    public IdamNotificationClient notificationClient(@Value("${notify.key}") String notificationKey) {
+    public IdamNotificationClient notificationClient(@Value("${notify.key}") String notificationKey, ObjectMapper objectMapper) {
+        objectMapper.registerModule(new JodaModule());
         return new IdamNotificationClient(notificationKey);
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Fixes 
"Joda date/time type `org.joda.time.DateTime` not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-joda" to enable handling (through reference chain: uk.gov.service.notify.Notification["createdAt"]) "


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
