### PR TITLE
Tidy up suppressions and suppress CVE-2023-4586

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -9,7 +9,7 @@
     <cve>CVE-2022-45688</cve>
   </suppress>
   <suppress>
-    <packageUrl regex="true">^.*netty.*$</packageUrl>
+    <packageUrl regex="true">^pkg:maven/io\.netty/netty.*$</packageUrl>
     <cve>CVE-2023-4586</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,77 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress until="2030-01-01">
-    <notes><![CDATA[
-     Suppressing as it's a false positive (see: https://pivotal.io/security/cve-2018-1258)
-   ]]></notes>
-    <gav regex="true">^org\.springframework\.security:spring-security-crypto:5.[0-9].[0-9].RELEASE</gav>
-    <cpe>cpe:/a:pivotal_software:spring_security</cpe>
-    <cve>CVE-2018-1258</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-        CVE is a json vulnerability for Node projects. False positive reported at https://github.com/jeremylong/DependencyCheck/issues/2794
-    ]]></notes>
-    <cve>CVE-2020-10663</cve>
-    <cve>CVE-2020-7712</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-        Needs review
-    ]]></notes>
-    <gav regex="true">^org\.springframework\.boot:spring-boot-starter-oauth2-resource-server:2.7.[0-9]</gav>
-    <cve>CVE-2018-1258</cve>
-    <cve>CVE-2021-22112</cve>
-    <cve>CVE-2022-22976</cve>
-    <cve>CVE-2022-22978</cve>
-  </suppress>
-  <!-- false positive CVEs from the dependency check plugin -->
-  <suppress>
-    <gav regex="true">^.*spring-.*$</gav>
-    <cve>CVE-2016-1000027</cve>
-    <cve>CVE-2022-22976</cve>
-    <cve>CVE-2022-22978</cve>
-    <cve>CVE-2022-31690</cve>
-    <cve>CVE-2022-31692</cve>
-  </suppress>
-  <suppress>
-    <gav regex="true">^.*tomcat-.*$</gav>
-    <cve>CVE-2022-34305</cve>
-  </suppress>
   <suppress>
     <gav regex="true">^.*jackson-databind.*$</gav>
-    <cve>CVE-2022-42003</cve>
     <cve>CVE-2023-35116</cve>
-  </suppress>
-  <!-- False positive: https://github.com/jeremylong/DependencyCheck/issues/5213  -->
-  <suppress>
-    <packageUrl regex="true">^pkg:maven/org\.latencyutils/LatencyUtils@.*$</packageUrl>
-    <cve>CVE-2021-4277</cve>
-  </suppress>
-  <!-- False positive:  https://github.com/jeremylong/DependencyCheck/issues/5233  -->
-  <suppress>
-    <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
-    <cve>CVE-2021-4235</cve>
-    <cve>CVE-2022-3064</cve>
-  </suppress>
-  <suppress>
-    <packageUrl regex="true">^pkg:maven/commons\-fileupload/commons\-fileupload@.*$</packageUrl>
-    <cve>CVE-2021-37533</cve>
-  </suppress>
-  <suppress>
-    <packageUrl regex="true">^pkg:maven/commons\-io/commons\-io@.*$</packageUrl>
-    <cve>CVE-2021-37533</cve>
-  </suppress>
-  <suppress>
-    <packageUrl regex="true">^pkg:maven/org\.postgresql/postgresql@.*$</packageUrl>
-    <cve>CVE-2022-41946</cve>
-  </suppress>
-  <suppress>
-    <gav regex="true">^.*commons-fileupload.*$</gav>
-    <cve>CVE-2023-24998</cve>
   </suppress>
   <suppress>
     <packageUrl regex="true">^.*org\.json.*$</packageUrl>
     <cve>CVE-2022-45688</cve>
+  </suppress>
+  <suppress>
+    <packageUrl regex="true">^.*netty.*$</packageUrl>
+    <cve>CVE-2023-4586</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-8938

### Change description ###
Suppress CVE-2023-4586 as there is no netty version that is not vulnerable currently.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
