### PR TITLE
Fix functional tests

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -38,6 +38,7 @@ withPipeline(type, product, component) {
   expires(expiresAfter)
 
   onPR() {
+        env.NONPROD_ENVIRONMENT_NAME = 'preview'
         Map<String, String> vaultEnvironmentOverrides = ['aat':'preview']
         overrideVaultEnvironments(vaultEnvironmentOverrides)
   }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -31,12 +31,18 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 // 1. https://github.com/hmcts/cnp-jenkins-library
 // 2. https://hmcts.github.io/ways-of-working/common-pipeline/common-pipeline.html#common-pipeline
 withPipeline(type, product, component) {
-  loadVaultSecrets(secrets)
   enableSlackNotifications('#idam_tech')
   enableAksStagingDeployment()
   disableLegacyDeployment()
 //  syncBranchesWithMaster(branchesToSync)
   expires(expiresAfter)
+
+  onPR() {
+        Map<String, String> vaultEnvironmentOverrides = ['aat':'preview']
+        overrideVaultEnvironments(vaultEnvironmentOverrides)
+  }
+
+  loadVaultSecrets(secrets)
 
   before('functionalTest:preview') {
     env.PUBLIC_URL = 'https://idam-web-public.preview.platform.hmcts.net'


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Functional tests are currently failing in the pipelines as they can't generate an access_token for the functional tests service. We think this is because they are using the aat client_secret of the service, and not the preview one.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
