### PR TITLE
SIDM-9466 detach conflict services

### DIFF
--- a/src/main/java/uk/gov/hmcts/cft/idam/testingsupportapi/controllers/ServiceProviderController.java
+++ b/src/main/java/uk/gov/hmcts/cft/idam/testingsupportapi/controllers/ServiceProviderController.java
@@ -50,7 +50,6 @@ public class ServiceProviderController {
             if (hsce.getStatusCode() == HttpStatus.CONFLICT) {
                 testingServiceProviderService.detachEntity(serviceProvider.getClientId());
                 Span.current().setAttribute(TraceAttribute.OUTCOME, "detached");
-                return serviceProvider;
             }
             throw hsce;
         }

--- a/src/main/java/uk/gov/hmcts/cft/idam/testingsupportapi/controllers/ServiceProviderController.java
+++ b/src/main/java/uk/gov/hmcts/cft/idam/testingsupportapi/controllers/ServiceProviderController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.HttpStatusCodeException;
 import uk.gov.hmcts.cft.idam.api.v2.common.model.ServiceProvider;
 import uk.gov.hmcts.cft.idam.testingsupportapi.repo.model.TestingSession;
 import uk.gov.hmcts.cft.idam.testingsupportapi.service.TestingServiceProviderService;
@@ -43,7 +44,16 @@ public class ServiceProviderController {
             .setAttribute(TraceAttribute.SESSION_ID, session.getId())
             .setAttribute(TraceAttribute.SESSION_CLIENT_ID, session.getClientId())
             .setAttribute(TraceAttribute.CLIENT_ID, serviceProvider.getClientId());
-        return testingServiceProviderService.createService(session.getId(), serviceProvider);
+        try {
+            return testingServiceProviderService.createService(session.getId(), serviceProvider);
+        } catch (HttpStatusCodeException hsce) {
+            if (hsce.getStatusCode() == HttpStatus.CONFLICT) {
+                testingServiceProviderService.detachEntity(serviceProvider.getClientId());
+                Span.current().setAttribute(TraceAttribute.OUTCOME, "detached");
+                return serviceProvider;
+            }
+            throw hsce;
+        }
 
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SIDM-9466

### Change description ###

When creating a service results in a conflict, set the testing entity state to detached so they are no longer cleaned up.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
