### PR TITLE
Sidm 9759 archived role ids

### DIFF
--- a/src/main/java/uk/gov/hmcts/cft/idam/api/v1/IdamV1StaleUserApi.java
+++ b/src/main/java/uk/gov/hmcts/cft/idam/api/v1/IdamV1StaleUserApi.java
@@ -1,0 +1,18 @@
+package uk.gov.hmcts.cft.idam.api.v1;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import uk.gov.hmcts.cft.idam.api.v1.common.model.V1UserWithRoleIds;
+import uk.gov.hmcts.cft.idam.api.v2.common.auth.IdamClientCredentialsConfig;
+
+@FeignClient(name = "idamv1staleuser", url = "${idam.api.url}", configuration = IdamClientCredentialsConfig.class)
+public interface IdamV1StaleUserApi {
+
+    /**
+     * Note this is a v1 call using client credentials
+     */
+    @PostMapping("/api/v1/staleUsers/{userId}")
+    void createArchivedUser(@PathVariable String userId, @RequestBody V1UserWithRoleIds v1User);
+}

--- a/src/main/java/uk/gov/hmcts/cft/idam/api/v1/common/model/V1UserWithRoleIds.java
+++ b/src/main/java/uk/gov/hmcts/cft/idam/api/v1/common/model/V1UserWithRoleIds.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 @Getter
 @Setter
-public class V1UserWithRolesIds {
+public class V1UserWithRoleIds {
 
     private String id;
     private String email;

--- a/src/main/java/uk/gov/hmcts/cft/idam/api/v1/common/model/V1UserWithRolesIds.java
+++ b/src/main/java/uk/gov/hmcts/cft/idam/api/v1/common/model/V1UserWithRolesIds.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 @Getter
 @Setter
-public class V1User {
+public class V1UserWithRolesIds {
 
     private String id;
     private String email;
@@ -19,7 +19,7 @@ public class V1User {
     private String ssoProvider;
 
     @JsonProperty("roles")
-    private List<String> roleNames;
+    private List<String> roleIds;
 
     private boolean active;
     private boolean locked;

--- a/src/main/java/uk/gov/hmcts/cft/idam/api/v1/common/util/UserConversionUtil.java
+++ b/src/main/java/uk/gov/hmcts/cft/idam/api/v1/common/util/UserConversionUtil.java
@@ -1,24 +1,26 @@
 package uk.gov.hmcts.cft.idam.api.v1.common.util;
 
-import uk.gov.hmcts.cft.idam.api.v1.common.model.V1User;
+import uk.gov.hmcts.cft.idam.api.v1.common.model.V1UserWithRolesIds;
 import uk.gov.hmcts.cft.idam.api.v2.common.model.AccountStatus;
 import uk.gov.hmcts.cft.idam.api.v2.common.model.RecordType;
 import uk.gov.hmcts.cft.idam.api.v2.common.model.User;
+
+import java.util.List;
 
 public class UserConversionUtil {
 
     private UserConversionUtil() {
     }
 
-    public static V1User convert(User input) {
-        V1User user = new V1User();
+    public static V1UserWithRolesIds convert(User input, List<String> roleIds) {
+        V1UserWithRolesIds user = new V1UserWithRolesIds();
         user.setId(input.getId());
         user.setEmail(input.getEmail());
         user.setForename(input.getForename());
         user.setSurname(input.getSurname());
         user.setSsoId(input.getSsoId());
         user.setSsoProvider(input.getSsoProvider());
-        user.setRoleNames(input.getRoleNames());
+        user.setRoleIds(roleIds);
         user.setCreateDate(input.getCreateDate());
         user.setLastModified(input.getLastModified());
         user.setPending(false);

--- a/src/main/java/uk/gov/hmcts/cft/idam/api/v1/common/util/UserConversionUtil.java
+++ b/src/main/java/uk/gov/hmcts/cft/idam/api/v1/common/util/UserConversionUtil.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.cft.idam.api.v1.common.util;
 
-import uk.gov.hmcts.cft.idam.api.v1.common.model.V1UserWithRolesIds;
+import uk.gov.hmcts.cft.idam.api.v1.common.model.V1UserWithRoleIds;
 import uk.gov.hmcts.cft.idam.api.v2.common.model.AccountStatus;
 import uk.gov.hmcts.cft.idam.api.v2.common.model.RecordType;
 import uk.gov.hmcts.cft.idam.api.v2.common.model.User;
@@ -12,8 +12,8 @@ public class UserConversionUtil {
     private UserConversionUtil() {
     }
 
-    public static V1UserWithRolesIds convert(User input, List<String> roleIds) {
-        V1UserWithRolesIds user = new V1UserWithRolesIds();
+    public static V1UserWithRoleIds convert(User input, List<String> roleIds) {
+        V1UserWithRoleIds user = new V1UserWithRoleIds();
         user.setId(input.getId());
         user.setEmail(input.getEmail());
         user.setForename(input.getForename());

--- a/src/main/java/uk/gov/hmcts/cft/idam/api/v2/IdamV2UserManagementApi.java
+++ b/src/main/java/uk/gov/hmcts/cft/idam/api/v2/IdamV2UserManagementApi.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import uk.gov.hmcts.cft.idam.api.v1.common.model.V1User;
+import uk.gov.hmcts.cft.idam.api.v1.common.model.V1UserWithRolesIds;
 import uk.gov.hmcts.cft.idam.api.v2.common.auth.IdamClientCredentialsConfig;
 import uk.gov.hmcts.cft.idam.api.v2.common.model.ActivatedUserRequest;
 import uk.gov.hmcts.cft.idam.api.v2.common.model.User;
@@ -44,5 +44,5 @@ public interface IdamV2UserManagementApi {
      * Note this is a v1 call using client credentials
      */
     @PostMapping("/api/v1/staleUsers/{userId}")
-    void createArchivedUser(@PathVariable String userId, @RequestBody V1User v1User);
+    void createArchivedUser(@PathVariable String userId, @RequestBody V1UserWithRolesIds v1User);
 }

--- a/src/main/java/uk/gov/hmcts/cft/idam/api/v2/IdamV2UserManagementApi.java
+++ b/src/main/java/uk/gov/hmcts/cft/idam/api/v2/IdamV2UserManagementApi.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import uk.gov.hmcts.cft.idam.api.v1.common.model.V1UserWithRolesIds;
+import uk.gov.hmcts.cft.idam.api.v1.common.model.V1UserWithRoleIds;
 import uk.gov.hmcts.cft.idam.api.v2.common.auth.IdamClientCredentialsConfig;
 import uk.gov.hmcts.cft.idam.api.v2.common.model.ActivatedUserRequest;
 import uk.gov.hmcts.cft.idam.api.v2.common.model.User;
@@ -33,16 +33,5 @@ public interface IdamV2UserManagementApi {
 
     @DeleteMapping("/api/v2/users/{userId}")
     void deleteUser(@PathVariable String userId);
-
-    /**
-     * Note this is a v1 call using client credentials
-     */
-    @PostMapping("/api/v1/staleUsers/{userId}/retire")
-    void archiveUser(@PathVariable String userId);
-
-    /**
-     * Note this is a v1 call using client credentials
-     */
-    @PostMapping("/api/v1/staleUsers/{userId}")
-    void createArchivedUser(@PathVariable String userId, @RequestBody V1UserWithRolesIds v1User);
+    
 }

--- a/src/main/java/uk/gov/hmcts/cft/idam/api/v2/IdamV2UserManagementApi.java
+++ b/src/main/java/uk/gov/hmcts/cft/idam/api/v2/IdamV2UserManagementApi.java
@@ -8,7 +8,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import uk.gov.hmcts.cft.idam.api.v1.common.model.V1UserWithRoleIds;
 import uk.gov.hmcts.cft.idam.api.v2.common.auth.IdamClientCredentialsConfig;
 import uk.gov.hmcts.cft.idam.api.v2.common.model.ActivatedUserRequest;
 import uk.gov.hmcts.cft.idam.api.v2.common.model.User;
@@ -33,5 +32,5 @@ public interface IdamV2UserManagementApi {
 
     @DeleteMapping("/api/v2/users/{userId}")
     void deleteUser(@PathVariable String userId);
-    
+
 }

--- a/src/main/java/uk/gov/hmcts/cft/idam/testingsupportapi/service/TestingUserService.java
+++ b/src/main/java/uk/gov/hmcts/cft/idam/testingsupportapi/service/TestingUserService.java
@@ -113,8 +113,13 @@ public class TestingUserService extends TestingEntityService<User> {
         if (StringUtils.isEmpty(requestUser.getId())) {
             requestUser.setId(UUID.randomUUID().toString());
         }
-        idamV2UserManagementApi.createArchivedUser(requestUser.getId(), UserConversionUtil.convert(requestUser));
+        idamV2UserManagementApi.createArchivedUser(requestUser.getId(), UserConversionUtil.convert(requestUser, getRoleIds(requestUser.getRoleNames())));
         return getUserByUserId(requestUser.getId());
+    }
+
+    private List<String> getRoleIds(List<String> roleNames) {
+        // For test users assume that role names and ids are always the same.
+        return roleNames;
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/cft/idam/testingsupportapi/service/TestingUserService.java
+++ b/src/main/java/uk/gov/hmcts/cft/idam/testingsupportapi/service/TestingUserService.java
@@ -116,7 +116,9 @@ public class TestingUserService extends TestingEntityService<User> {
         if (StringUtils.isEmpty(requestUser.getId())) {
             requestUser.setId(UUID.randomUUID().toString());
         }
-        idamV1StaleUserApi.createArchivedUser(requestUser.getId(), UserConversionUtil.convert(requestUser, getRoleIds(requestUser.getRoleNames())));
+        idamV1StaleUserApi.createArchivedUser(requestUser.getId(),
+                                              UserConversionUtil.convert(requestUser,
+                                                                         getRoleIds(requestUser.getRoleNames())));
         return getUserByUserId(requestUser.getId());
     }
 

--- a/src/main/java/uk/gov/hmcts/cft/idam/testingsupportapi/service/TestingUserService.java
+++ b/src/main/java/uk/gov/hmcts/cft/idam/testingsupportapi/service/TestingUserService.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpStatusCodeException;
+import uk.gov.hmcts.cft.idam.api.v1.IdamV1StaleUserApi;
 import uk.gov.hmcts.cft.idam.api.v1.common.util.UserConversionUtil;
 import uk.gov.hmcts.cft.idam.api.v2.IdamV2UserManagementApi;
 import uk.gov.hmcts.cft.idam.api.v2.common.model.AccountStatus;
@@ -36,6 +37,7 @@ import java.util.UUID;
 public class TestingUserService extends TestingEntityService<User> {
 
     private final IdamV2UserManagementApi idamV2UserManagementApi;
+    private final IdamV1StaleUserApi idamV1StaleUserApi;
 
     @Value("${cleanup.burner.batch-size:10}")
     private int expiredBurnerUserBatchSize;
@@ -53,9 +55,10 @@ public class TestingUserService extends TestingEntityService<User> {
 
     public TestingUserService(IdamV2UserManagementApi idamV2UserManagementApi,
                               TestingEntityRepo testingEntityRepo,
-                              JmsTemplate jmsTemplate) {
+                              JmsTemplate jmsTemplate, IdamV1StaleUserApi idamV1StaleUserApi) {
         super(testingEntityRepo, jmsTemplate);
         this.idamV2UserManagementApi = idamV2UserManagementApi;
+        this.idamV1StaleUserApi = idamV1StaleUserApi;
         this.clock = Clock.system(ZoneOffset.UTC);
     }
 
@@ -113,7 +116,7 @@ public class TestingUserService extends TestingEntityService<User> {
         if (StringUtils.isEmpty(requestUser.getId())) {
             requestUser.setId(UUID.randomUUID().toString());
         }
-        idamV2UserManagementApi.createArchivedUser(requestUser.getId(), UserConversionUtil.convert(requestUser, getRoleIds(requestUser.getRoleNames())));
+        idamV1StaleUserApi.createArchivedUser(requestUser.getId(), UserConversionUtil.convert(requestUser, getRoleIds(requestUser.getRoleNames())));
         return getUserByUserId(requestUser.getId());
     }
 

--- a/src/test/java/uk/gov/hmcts/cft/idam/testingsupportapi/service/TestingUserServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cft/idam/testingsupportapi/service/TestingUserServiceTest.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.hmcts.cft.idam.api.v1.IdamV1StaleUserApi;
 import uk.gov.hmcts.cft.idam.api.v2.IdamV2UserManagementApi;
 import uk.gov.hmcts.cft.idam.api.v2.common.error.SpringWebClientHelper;
 import uk.gov.hmcts.cft.idam.api.v2.common.model.RecordType;
@@ -56,7 +57,8 @@ class TestingUserServiceTest {
 
     @Mock
     IdamV2UserManagementApi idamV2UserManagementApi;
-
+    @Mock
+    IdamV1StaleUserApi idamV1StaleUserApi;
     @Mock
     TestingEntityRepo testingEntityRepo;
 
@@ -95,7 +97,6 @@ class TestingUserServiceTest {
         assertEquals(testUser, result);
 
         verify(testingEntityRepo, times(1)).save(testingEntityArgumentCaptor.capture());
-        verify(idamV2UserManagementApi, never()).archiveUser("test-user-id");
 
         TestingEntity testingEntity = testingEntityArgumentCaptor.getValue();
 
@@ -120,7 +121,6 @@ class TestingUserServiceTest {
         User result = underTest.createTestUser(sessionId, testUser, "test-secret");
         assertEquals(testUser, result);
         verify(testingEntityRepo, times(1)).save(testingEntityArgumentCaptor.capture());
-        verify(idamV2UserManagementApi, never()).archiveUser("test-user-id");
 
         TestingEntity testingEntity = testingEntityArgumentCaptor.getValue();
 
@@ -150,9 +150,8 @@ class TestingUserServiceTest {
         assertEquals(TestingEntityType.USER, testingEntity.getEntityType());
         assertNotNull(testingEntity.getCreateDate());
 
-        verify(idamV2UserManagementApi, times(1)).createArchivedUser(any(), any());
+        verify(idamV1StaleUserApi, times(1)).createArchivedUser(any(), any());
         verify(idamV2UserManagementApi, never()).createUser(any());
-        verify(idamV2UserManagementApi, never()).archiveUser("test-user-id");
     }
 
     /**


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SIDM-9759

### Change description ###

Tidy up V1 stale user api code and make it clear that stale users works with role ids, not names.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
